### PR TITLE
Align configurations for SQLite-only operation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,14 +15,14 @@
   "remoteEnv": {
     "LOGS_DIR": "logs",
     "N8N_USER_FOLDER": "/workspaces/n8n_data",
-    "DB_PASSWORD": "${localEnv:DB_PASSWORD}",
+    // "DB_PASSWORD": "${localEnv:DB_PASSWORD}",
     "N8N_ENCRYPTION_KEY": "${localEnv:N8N_ENCRYPTION_KEY}"
   },
   
   "secrets": {
-    "DB_PASSWORD": {
-      "description": "PostgreSQL database password"
-    },
+    // "DB_PASSWORD": {
+    //   "description": "PostgreSQL database password"
+    // },
     "N8N_ENCRYPTION_KEY": {
       "description": "n8n data encryption key"
     }
@@ -36,7 +36,7 @@
       "extensions": [
         "anthropic.claude-code",
         "ms-azuretools.vscode-docker",
-        "ckolkman.vscode-postgres",
+        // "ckolkman.vscode-postgres",
         "esbenp.prettier-vscode",
         "humao.rest-client"
       ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,11 +15,13 @@
   "remoteEnv": {
     "LOGS_DIR": "logs",
     "N8N_USER_FOLDER": "/workspaces/n8n_data",
+    // PostgreSQL only: uncomment the line below when switching to PostgreSQL
     // "DB_PASSWORD": "${localEnv:DB_PASSWORD}",
     "N8N_ENCRYPTION_KEY": "${localEnv:N8N_ENCRYPTION_KEY}"
   },
   
   "secrets": {
+    // PostgreSQL only: uncomment the block below when switching to PostgreSQL
     // "DB_PASSWORD": {
     //   "description": "PostgreSQL database password"
     // },
@@ -36,6 +38,7 @@
       "extensions": [
         "anthropic.claude-code",
         "ms-azuretools.vscode-docker",
+        // PostgreSQL only: uncomment the line below when switching to PostgreSQL
         // "ckolkman.vscode-postgres",
         "esbenp.prettier-vscode",
         "humao.rest-client"

--- a/.devcontainer/scripts/post-attach.d/02-n8n-secret-setup.nolog.sh
+++ b/.devcontainer/scripts/post-attach.d/02-n8n-secret-setup.nolog.sh
@@ -6,9 +6,9 @@ echo "=== n8n Secret Setup ==="
 
 # Check if secrets are missing
 missing_secrets=""
-if [ -z "$DB_PASSWORD" ]; then
-    missing_secrets="$missing_secrets DB_PASSWORD"
-fi
+# if [ -z "$DB_PASSWORD" ]; then
+#     missing_secrets="$missing_secrets DB_PASSWORD"
+# fi
 if [ -z "$N8N_ENCRYPTION_KEY" ]; then
     missing_secrets="$missing_secrets N8N_ENCRYPTION_KEY"
 fi

--- a/.devcontainer/scripts/post-attach.d/02-n8n-secret-setup.nolog.sh
+++ b/.devcontainer/scripts/post-attach.d/02-n8n-secret-setup.nolog.sh
@@ -6,6 +6,7 @@ echo "=== n8n Secret Setup ==="
 
 # Check if secrets are missing
 missing_secrets=""
+# PostgreSQL only: uncomment the block below when switching to PostgreSQL
 # if [ -z "$DB_PASSWORD" ]; then
 #     missing_secrets="$missing_secrets DB_PASSWORD"
 # fi

--- a/.devcontainer/scripts/post-create.d/01-generate-env.sh
+++ b/.devcontainer/scripts/post-create.d/01-generate-env.sh
@@ -32,15 +32,16 @@ else
 fi
 
 # Log secret status (non-interactive)
-if [ -z "$DB_PASSWORD" ]; then
-    echo "ℹ️  DB_PASSWORD secret not configured"
-fi
+# if [ -z "$DB_PASSWORD" ]; then
+#     echo "ℹ️  DB_PASSWORD secret not configured"
+# fi
 
 if [ -z "$N8N_ENCRYPTION_KEY" ]; then
     echo "ℹ️  N8N_ENCRYPTION_KEY secret not configured"
 fi
 
-if [ -n "$DB_PASSWORD" ] && [ -n "$N8N_ENCRYPTION_KEY" ]; then
+# if [ -n "$DB_PASSWORD" ] && [ -n "$N8N_ENCRYPTION_KEY" ]; then
+if [ -n "$N8N_ENCRYPTION_KEY" ]; then
     echo "✅ Required secrets configured"
 else
     echo "ℹ️  Some secrets missing - will be prompted to set up on first attach"

--- a/.devcontainer/scripts/post-create.d/01-generate-env.sh
+++ b/.devcontainer/scripts/post-create.d/01-generate-env.sh
@@ -32,6 +32,7 @@ else
 fi
 
 # Log secret status (non-interactive)
+# PostgreSQL only: uncomment the block below when switching to PostgreSQL
 # if [ -z "$DB_PASSWORD" ]; then
 #     echo "ℹ️  DB_PASSWORD secret not configured"
 # fi
@@ -40,6 +41,7 @@ if [ -z "$N8N_ENCRYPTION_KEY" ]; then
     echo "ℹ️  N8N_ENCRYPTION_KEY secret not configured"
 fi
 
+# PostgreSQL only: uncomment the condition below when switching to PostgreSQL
 # if [ -n "$DB_PASSWORD" ] && [ -n "$N8N_ENCRYPTION_KEY" ]; then
 if [ -n "$N8N_ENCRYPTION_KEY" ]; then
     echo "✅ Required secrets configured"

--- a/.devcontainer/scripts/start-n8n.sh
+++ b/.devcontainer/scripts/start-n8n.sh
@@ -17,6 +17,7 @@ else
 fi
 
 # Add secrets from Codespaces Secrets
+# PostgreSQL only: uncomment the block below when switching to PostgreSQL
 # if [ -n "$DB_PASSWORD" ]; then
 #     export DB_POSTGRESDB_PASSWORD="$DB_PASSWORD"
 #     echo "✅ DB_PASSWORD configured"

--- a/.devcontainer/scripts/start-n8n.sh
+++ b/.devcontainer/scripts/start-n8n.sh
@@ -17,13 +17,13 @@ else
 fi
 
 # Add secrets from Codespaces Secrets
-if [ -n "$DB_PASSWORD" ]; then
-    export DB_POSTGRESDB_PASSWORD="$DB_PASSWORD"
-    echo "✅ DB_PASSWORD configured"
-else
-    echo "❌ DB_PASSWORD missing from Codespaces Secrets"
-    exit 1
-fi
+# if [ -n "$DB_PASSWORD" ]; then
+#     export DB_POSTGRESDB_PASSWORD="$DB_PASSWORD"
+#     echo "✅ DB_PASSWORD configured"
+# else
+#     echo "❌ DB_PASSWORD missing from Codespaces Secrets"
+#     exit 1
+# fi
 
 if [ -n "$N8N_ENCRYPTION_KEY" ]; then
     export N8N_ENCRYPTION_KEY="$N8N_ENCRYPTION_KEY"

--- a/.env.template
+++ b/.env.template
@@ -1,9 +1,19 @@
 # Copy this file to .env and update the values
 
 # Database Configuration (non-secret)
+# ============================================
+# SQLite Configuration (currently active)
+# ============================================
+DB_TYPE=sqlite
+DB_SQLITE_POOL_SIZE=5
+
+# ============================================
+# PostgreSQL Configuration (currently disabled)
+# Uncomment the lines below and comment out SQLite config to switch to PostgreSQL
+# ============================================
+# DB_TYPE=postgresdb
 # DB_NAME=n8n_prod_db
 # DB_USER=n8n_service_user
-DB_TYPE=sqlite
 # DB_POSTGRESDB_HOST=localhost
 # DB_POSTGRESDB_PORT=5432
 # DB_POSTGRESDB_DATABASE=n8n_prod_db
@@ -20,7 +30,8 @@ WEBHOOK_URL=<YOUR_CODESPACE_URL>
 N8N_USER_FOLDER=/workspaces/n8n_data
 
 # Performance and Task Runner Configuration
-DB_SQLITE_POOL_SIZE=5
 N8N_RUNNERS_ENABLED=true
 
-# Note: DB_PASSWORD and N8N_ENCRYPTION_KEY are provided via Codespaces Secrets
+# Secrets Configuration
+# Note: N8N_ENCRYPTION_KEY is provided via Codespaces Secrets (required for both SQLite and PostgreSQL)
+# Note: DB_PASSWORD is only needed for PostgreSQL and should be provided via Codespaces Secrets when using PostgreSQL

--- a/.env.template
+++ b/.env.template
@@ -1,14 +1,14 @@
 # Copy this file to .env and update the values
 
 # Database Configuration (non-secret)
-DB_NAME=n8n_prod_db
-DB_USER=n8n_service_user
-DB_TYPE=postgresdb
-DB_POSTGRESDB_HOST=localhost
-DB_POSTGRESDB_PORT=5432
-DB_POSTGRESDB_DATABASE=n8n_prod_db
-DB_POSTGRESDB_USER=n8n_service_user
-DB_POSTGRESDB_SSL_MODE=disable
+# DB_NAME=n8n_prod_db
+# DB_USER=n8n_service_user
+DB_TYPE=sqlite
+# DB_POSTGRESDB_HOST=localhost
+# DB_POSTGRESDB_PORT=5432
+# DB_POSTGRESDB_DATABASE=n8n_prod_db
+# DB_POSTGRESDB_USER=n8n_service_user
+# DB_POSTGRESDB_SSL_MODE=disable
 
 # n8n Configuration
 N8N_HOST=<YOUR_CODESPACE_URL>


### PR DESCRIPTION
## Summary
- Configure all scripts and configs to default to SQLite instead of PostgreSQL
- Add clear comments for switching between SQLite and PostgreSQL
- Remove PostgreSQL dependencies from default configuration